### PR TITLE
fix(client): 修复版本检测时 System.db 不存在导致的崩溃

### DIFF
--- a/Client/Scenes/LoginScene.cs
+++ b/Client/Scenes/LoginScene.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Net.Sockets;
 using System.Threading;
@@ -285,7 +285,9 @@ namespace Client.Scenes
             CheckDbBox.CloseButton.MouseClick += (o, e1) => CEnvir.Target.Close();
             CheckDbBox.Modal = true;
 
-            var datas = File.ReadAllBytes(@"./Data/System.db");
+            byte[] datas = new byte[0];
+            if (File.Exists(@"./Data/System.db"))
+                datas = File.ReadAllBytes(@"./Data/System.db");
 
 
             CEnvir.Connection.Enqueue(new C.CheckClientDb()


### PR DESCRIPTION
在 CheckDbVersion() 方法中直接调用 File.ReadAllBytes 读取 System.db。若该文件在客户端目录中不存在（如首次启动或被玩家误删），会直接抛出 FileNotFoundException 导致客户端崩溃。

本次修复增加了 File.Exists 检查，文件不存在时传入空字节数组，让后续的哈希计算和服务器校验流程能够正常继续执行。（保留了原作者设计的 #if DEBUG 跳过逻辑）。