### PR TITLE
Fix & Refactor: 优化对象特效渲染机制并修复部分内存泄漏

### DIFF
--- a/Client/Models/MapObject.cs
+++ b/Client/Models/MapObject.cs
@@ -4592,6 +4592,40 @@ namespace Client.Models
         {
             GameScene.Game.MapControl.RemoveObject(this);
             ClearEffects();
+
+            // ★ Fix: 从静态缓存中解除 NameLabel 引用
+            // 不能调用 Dispose()，因为 NameLabel 走享元模式（同名怪物共享同一个 DXLabel 实例）
+            // 正确做法：从列表中移除引用，当列表为空时再移除字典条目，让 GC 自然回收
+            if (NameLabel != null)
+            {
+                if (!string.IsNullOrEmpty(Name) && NameLabels.TryGetValue(Name, out List<DXLabel> names))
+                {
+                    names.Remove(NameLabel);
+                    if (names.Count == 0)
+                        NameLabels.Remove(Name);
+                }
+                NameLabel = null;
+            }
+
+            // ★ Fix: 从静态缓存中解除 TitleNameLabel 引用
+            if (TitleNameLabel != null)
+            {
+                if (!string.IsNullOrEmpty(Title) && NameLabels.TryGetValue(Title, out List<DXLabel> titles))
+                {
+                    titles.Remove(TitleNameLabel);
+                    if (titles.Count == 0)
+                        NameLabels.Remove(Title);
+                }
+                TitleNameLabel = null;
+            }
+
+            // ★ Fix: 从全局列表中解除 ChatLabel 引用
+            // ChatLabel 不是享元模式，每次怪物发言都会创建新实例，需要在怪物移除时清理
+            if (ChatLabel != null)
+            {
+                ChatLabels.Remove(ChatLabel);
+                ChatLabel = null;
+            }
         }
     }
 }

--- a/Client/Models/MapObject.cs
+++ b/Client/Models/MapObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Drawing;
@@ -4202,6 +4202,8 @@ namespace Client.Models
         }
         public virtual void DrawName()
         {
+            if (!Visible) return;
+
             if (NameLabel != null)
             {
                 int x = DrawX + (48 - NameLabel.Size.Width)/2;
@@ -4241,6 +4243,7 @@ namespace Client.Models
         }
         public void DrawChat()
         {
+            if (!Visible) return;
             if (ChatLabel == null || ChatLabel.IsDisposed) return;
 
             if (CEnvir.Now > ChatTime) return;

--- a/Client/Models/MapObject.cs
+++ b/Client/Models/MapObject.cs
@@ -307,6 +307,12 @@ namespace Client.Models
         
         public virtual void Process()
         {
+            for (int i = Effects.Count - 1; i >= 0; i--)
+            {
+                if (Effects[i].IsRemoved)
+                    Effects.RemoveAt(i);
+            }
+
             DamageInfo previous = null;
             for (int index = 0; index < DamageList.Count; index++)
             {

--- a/Client/Models/MapObject.cs
+++ b/Client/Models/MapObject.cs
@@ -494,6 +494,7 @@ namespace Client.Models
                     if (Visible && Config.清理尸体)
                     {
                         Visible = false;
+                        ClearEffects();
                         break;
                     }
                     else if (!Visible && !Config.清理尸体)
@@ -4562,10 +4563,8 @@ namespace Client.Models
             DeveloperEffect = null;
         }
 
-        public virtual void Remove()
+        public void ClearEffects()
         {
-            GameScene.Game.MapControl.RemoveObject(this);
-
             MagicShieldEnd();
             CelestialLightEnd();
             WraithGripEnd();
@@ -4582,8 +4581,17 @@ namespace Client.Models
             for (int i = Effects.Count - 1; i >= 0; i--)
             {
                 MirEffect effect = Effects[i];
-                effect.Remove();
+                if (effect.Target == this && effect.Loop)
+                {
+                    effect.Remove();
+                }
             }
+        }
+
+        public virtual void Remove()
+        {
+            GameScene.Game.MapControl.RemoveObject(this);
+            ClearEffects();
         }
     }
 }

--- a/Client/Models/MapObject.cs
+++ b/Client/Models/MapObject.cs
@@ -4130,7 +4130,11 @@ namespace Client.Models
                 DrawFormat = TextFormatFlags.WordBreak | TextFormatFlags.WordEllipsis ,
             };
             ChatLabel.Size = DXLabel.GetHeight(ChatLabel, chatWidth);
-            ChatLabel.Disposing += (o, e) => ChatLabels.Remove(ChatLabel);
+            // ★ Fix: 不订阅 Disposing 事件
+            // 原订阅会创建捕获 this (MapObject) 的 lambda 闭包，
+            // 而 static ChatLabels 持有 DXLabel，DXLabel 持有闭包，闭包持有 this，
+            // 导致 MonsterObject 被静态字典间接持有无法被 GC 回收。
+            // Remove() 方法已负责从 ChatLabels 中清理引用，此处订阅纯属多余且有害。
             ChatLabels.Add(ChatLabel);
 
         }
@@ -4160,7 +4164,7 @@ namespace Client.Models
                         IsVisible = true,
                     };
 
-                    NameLabel.Disposing += (o, e) => names.Remove(NameLabel);
+                    // ★ Fix: 不订阅 Disposing 事件（同上，防止闭包持有 this 导致 MonsterObject 泄漏）
                     names.Add(NameLabel);
                 }
             }
@@ -4202,7 +4206,7 @@ namespace Client.Models
                         IsVisible = true,
                     };
 
-                    TitleNameLabel.Disposing += (o, e) => titles.Remove(TitleNameLabel);
+                    // ★ Fix: 不订阅 Disposing 事件（同上）
                     titles.Add(TitleNameLabel);
                 }
             }

--- a/Client/Models/MirEffect.cs
+++ b/Client/Models/MirEffect.cs
@@ -211,6 +211,7 @@ namespace Client.Models
         public void Draw()
         {
             if (CEnvir.Now < StartTime || Library == null) return;
+            if (Loop && Target != null && !Target.Visible) return;
 
             //if (Blend)
             //    Library.DrawBlend(DrawFrame, DrawX, DrawY, DrawColour, UseOffSet, BlendRate, ImageType.Image);

--- a/Client/Models/MirEffect.cs
+++ b/Client/Models/MirEffect.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -32,6 +32,7 @@ namespace Client.Models
         public float BlendRate = 0.9F;
         public bool UseOffSet = true;
         public bool Loop = false;
+        public bool IsRemoved = false;
 
         public int DrawX
         {
@@ -235,6 +236,7 @@ namespace Client.Models
 
         public void Remove()
         {
+            IsRemoved = true;
             CompleteAction = null;
             FrameAction = null;
             GameScene.Game.MapControl.Effects.Remove(this);

--- a/Client/Models/MonsterObject.cs
+++ b/Client/Models/MonsterObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -3606,6 +3606,7 @@ namespace Client.Models
                             break;
                         case MirAction.Dead:
                             Visible = false;
+                            ClearEffects();
                             break;
                     }
                     break;
@@ -3620,6 +3621,7 @@ namespace Client.Models
                     {
                         case MirAction.Dead:
                             Visible = false;
+                            ClearEffects();
                             break;
                     }
                     break;


### PR DESCRIPTION
## 问题描述

在同一张地图长时间挂机（通常 1~2 小时后）会出现以下症状：
- GPU 占用率持续攀升至满载
- 画面出现撕裂、抖动
- UI 控件（名字标签、聊天气泡）频繁闪烁
- 游戏帧率明显下降

通过 Visual Studio 内存诊断工具确认，上述症状由多个独立的资源泄漏叠加引发。

---

## 根因与修复

本次 PR 针对 `MapObject`、`MirEffect`、`MonsterObject` 三个类，修复了以下问题：

### 1. 隐形对象仍在每帧执行 UI 渲染（GPU 填充率浪费）

**根因：** 开启"清理尸体"功能后，死亡怪物的 `Visible` 被置为 `false`，
但 `DrawName()` 和 `DrawChat()` 缺少可见性判断，导致地图上积累的大量隐形尸体
每帧仍执行名字标签和聊天气泡的定位与绘制调用，产生密集的无效 GPU 填充。

**修复：** 在 `DrawName()` 和 `DrawChat()` 开头增加 `if (!Visible) return` 早退判断。

> 注意：`DrawDamage()` 有意未添加此判断，确保怪物死亡瞬间的最后一击伤害飘字仍可正常显示。

---

### 2. `MirEffect` 特效实例在播放完毕后永久堆积（内存泄漏）

**根因：** `MirEffect.Remove()` 将特效从全局渲染列表（`MapControl.Effects`）移除，
但范围型技能特效（`Target = null`）在 `Remove()` 时执行 `Target?.Effects.Remove(this)` 
因 null 而跳过，导致特效实例在施法者的 `Effects` 列表中永久堆积，长时间挂机后累积大量废弃对象。

**修复：** 
- 为 `MirEffect` 新增 `IsRemoved` 标记字段
- `Remove()` 执行时第一步置 `IsRemoved = true`
- 在 `MapObject.Process()` 的帧循环中统一清理 `IsRemoved` 的特效实例

---

### 3. 怪物死亡后持续循环型特效（光环、气场等）未被终止（持续 GPU 渲染）

**根因：** 原 `Remove()` 方法中对所有特效一刀切地调用 `effect.Remove()`，
导致怪物的一次性死亡动效（如骨骼爆炸、鬼魂消散，`Loop=false`）也被提前终止，
视觉表现丢失；同时持续循环特效（`Loop=true`）在怪物不可见后仍继续每帧渲染。

**修复：**
- 将特效清理逻辑从 `Remove()` 中提取为独立方法 `ClearEffects()`
- `ClearEffects()` 只终止 `Loop=true` 且 `Target==this` 的持续型特效，保留一次性动效的自然播放
- 在 `MirEffect.Draw()` 增加防御性判断：`Loop` 型特效若目标不可见则跳过绘制
- 在 `UpdateFrame()` 的死亡状态分支、`Remove()` 以及特殊怪物（Shinsu、InfernalSoldier）
  的 `SetAction()` 死亡分支中统一调用 `ClearEffects()`

---

### 4. 怪物对象移除时未清理 DXLabel 静态缓存引用（VRAM 持续耗尽）

**根因：** `MapObject.Remove()` 原来只调用 `ClearEffects()`，
从未从以下静态结构中解除引用：
- `NameLabels`（静态字典，享元模式，存储同名怪物共享的 `DXLabel`）
- `ChatLabels`（全局列表）

导致每次怪物死亡移除后，`DXLabel` 实例及其关联的 D3D Surface、Texture 永久积压在静态结构中。
VS 诊断数据：2 小时挂机后累积约 12790 个泄漏 DXLabel，关联 7637 个 D3D Surface 和 7309 个 Texture。

**修复：** 在 `Remove()` 中补充对 `NameLabel`、`TitleNameLabel`、`ChatLabel` 的引用解除逻辑。
注意：由于 `NameLabel` 采用享元模式（同名怪物共享同一实例），不能调用 `Dispose()`，
正确做法是从列表中移除引用，当列表清空时再删除字典条目，由 GC 自然回收。

---

### 5. Disposing 事件 lambda 订阅导致 MonsterObject 无法被 GC 回收（对象泄漏）

**根因：** `NameChanged()` 和 `Chat()` 中三处 lambda 订阅捕获了 `this`（MapObject 实例），
形成如下引用链：
static NameLabels 字典 → DXLabel → Disposing 事件 → lambda 闭包 → 整个 MonsterObject
由于享元模式下 `DXLabel.Dispose()` 从不被调用，`Disposing` 事件永远不触发，
lambda 闭包永远不执行，却将 MonsterObject 永久钉在内存中无法被 GC 回收。

VS 诊断数据：2.5 小时挂机中 `MapObject+<>c__DisplayClass` 闭包增长 +3786 个。

**修复：** 删除三处 Disposing lambda 订阅。`Remove()` 方法已承担从静态缓存清理引用的职责，
此处订阅完全冗余且有害。

---

## 涉及文件

| 文件 | 改动性质 |
|---|---|
| `Client/Models/MapObject.cs` | 修改（渲染拦截 + 特效生命周期 + Label 缓存清理 + 删除 Disposing 订阅） |
| `Client/Models/MirEffect.cs` | 修改（IsRemoved 标记 + Draw 可见性判断） |
| `Client/Models/MonsterObject.cs` | 修改（特殊怪物死亡时调用 ClearEffects） |

## 测试情况

在同一张地图挂机超过 2 小时，GPU 占用稳定，VRAM 使用量趋于恒定，
未出现画面撕裂、UI 闪烁和帧率下降。怪物死亡动效、最后一击飘字均表现正常。
