### PR TITLE
Fix: 修复 ItemObject 地面物品的 DXLabel 缓存泄漏与闭包持有对象问题

### DIFF
--- a/Client/Models/ItemObject.cs
+++ b/Client/Models/ItemObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -276,7 +276,7 @@ namespace Client.Models
                         IsVisible = true,
                     };
 
-                    TitleNameLabel.Disposing += (o, e) => titles.Remove(TitleNameLabel);
+                    // ★ Fix: 不订阅 Disposing 事件（同 MapObject 修复，防止闭包捕获 this 导致 ItemObject 无法被 GC）
                     titles.Add(TitleNameLabel);
                 }
             }
@@ -306,7 +306,7 @@ namespace Client.Models
                     IsVisible = true,
                 };
 
-                FocusLabel.Disposing += (o, e) => focused.Remove(FocusLabel);
+                // ★ Fix: 不订阅 Disposing 事件（同 MapObject 修复）
                 focused.Add(FocusLabel);
             }
         }
@@ -319,12 +319,27 @@ namespace Client.Models
 
         public override void Remove()
         {
+            // ★ Fix: 在 base.Remove() 之前清理 FocusLabel
+            // FocusLabel 由 ItemObject.NameChanged() 放入 NameLabels[Name] 列表，
+            // base.Remove() 只清理 NameLabel，FocusLabel 需要在这里单独处理，
+            // 否则列表不会清空，NameLabels 字典条目永久积压。
+            if (FocusLabel != null)
+            {
+                if (!string.IsNullOrEmpty(Name) && NameLabels.TryGetValue(Name, out List<DXLabel> focused))
+                {
+                    focused.Remove(FocusLabel);
+                    if (focused.Count == 0)
+                        NameLabels.Remove(Name);
+                }
+                FocusLabel = null;
+            }
+
             if (FilterSet != null)
             {
                 FilterSet.ShowChanged -= OnNameShowChanged;
                 FilterSet = null;
             }
-            
+
             base.Remove();
         }
     }


### PR DESCRIPTION
## 问题描述

与 pr-all-optimizations 中 MapObject 修复相同的问题模式，发生在 `ItemObject`（地图掉落物品对象）。
VS 诊断：`ItemObject+<>c__DisplayClass` 闭包在 2.5 小时挂机中累积 +4908 个。

---

## 根因与修复

### 1. Disposing 事件 lambda 订阅导致 ItemObject 无法被 GC 回收

**根因：** `ItemObject.NameChanged()` 中两处 lambda 订阅（`TitleNameLabel.Disposing`、
`FocusLabel.Disposing`）捕获了 `this`（ItemObject 实例），
与 `NameLabels` 静态字典形成引用链，导致 ItemObject 无法被 GC 回收。

**修复：** 删除两处 Disposing lambda 订阅。`Remove()` 方法已承担清理职责，订阅纯属冗余且有害。

---

### 2. FocusLabel 未在 Remove() 中清理，导致 NameLabels 字典条目永久积压

**根因：** `FocusLabel`（物品鼠标悬浮时的高亮标签）由 `NameChanged()` 放入 `NameLabels[Name]` 列表，
但 `base.Remove()` 只清理 `NameLabel`，不清理 `FocusLabel`，
导致同名物品对应的 List 永远不会清空，`NameLabels` 字典条目持续积压，关联的 DXLabel 无法被回收。

**修复：** 在 `ItemObject.Remove()` 中补充 `FocusLabel` 的引用解除逻辑（先于 `base.Remove()` 执行）。

---

## 涉及文件

| 文件 | 改动性质 |
|---|---|
| `Client/Models/ItemObject.cs` | 修改（删除 2 处 Disposing 订阅 + 补充 FocusLabel 清理） |

## 与其他 PR 的关系

本 PR 与 pr-all-optimizations 修改的文件完全不重叠，可独立合入，无顺序要求。
