### PR TITLE
Fix: 修复小地图玩家点每次更新无条件创建 DXControl 导致 D3D Surface 持续泄漏

### DIFF
--- a/Client/Scenes/Views/MiniMapDialog.cs
+++ b/Client/Scenes/Views/MiniMapDialog.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -258,6 +258,13 @@ namespace Client.Scenes.Views
             int y = (minY + maxY) / 2;
 
 
+            // ★ Fix: 覆盖字典条目前先 Dispose 旧控件，防止地图重加载时旧 DXImageControl 积压
+            if (MapInfoObjects.TryGetValue(ob, out DXControl existing))
+            {
+                existing.Dispose();
+                MapInfoObjects.Remove(ob);
+            }
+
             DXImageControl control;
             MapInfoObjects[ob] = control = new DXImageControl
             {
@@ -387,14 +394,23 @@ namespace Client.Scenes.Views
                     // 当前人物：6x6 magenta外框，内部2x2 cyan点，外框宽度2
                     size = new Size(6, 6);
                     
-                    new DXControl
+                    // ★ Fix: 与Boss的处理方式保持一致，只在没有子控件时才创建
+                    // 原来无条件 new DXControl，每次 Update() 都创建一个新的子控件
+                    // 而每个子控件的 DrawTexture=true 会触发 CreateTexture() 分配 D3D Surface
+                    // 导致 2.5小时挂机后累积 ~5741 个泄漏子控件和 Surface，直接填满 VRAM
+                    if (control.Controls.Count == 0)
                     {
-                        Parent = control,
-                        Location = new Point(2, 2),
-                        BackColour = Color.Cyan,
-                        DrawTexture = true,
-                        Size = new Size(2, 2)
-                    };
+                        new DXControl
+                        {
+                            Parent = control,
+                            Location = new Point(2, 2),
+                            BackColour = Color.Cyan,
+                            DrawTexture = true,
+                            Size = new Size(2, 2)
+                        };
+                    }
+                    else
+                        control.Controls[0].BackColour = Color.Cyan;
 
                     colour = Color.Magenta;
                 }


### PR DESCRIPTION
## 问题描述

VS 诊断：`DXControl`（基类）实例数与 D3D Surface 数在 2.5 小时挂机中均增长 +5741，
呈精确 1:1 匹配，定位至 `MiniMapDialog.Update(ClientObjectData)` 方法中处理当前玩家点的分支。

---

## 根因与修复

### 1. 玩家点子控件每次 Update 无条件创建（Surface 持续堆积）

**根因：** 处理当前玩家位置点时，原代码无条件执行：
```csharp
new DXControl { Parent = control, DrawTexture = true, ... };
```
`DrawTexture = true` 会触发 `CreateTexture()`，在 VRAM 中分配一个 D3D Surface。
由于每次收到位置更新包（挂机约每秒 0.88 次）都创建一个新子控件，
旧子控件既未被 Dispose 也未从父控件移除，2.5 小时积累约 5741 个泄漏 Surface，直接填满 VRAM。

同文件处理 Boss 怪物点的分支已有正确的保护写法：
```csharp
if (control.Controls.Count == 0)  // 只在没有子控件时才创建
    new DXControl { ... };
else
    control.Controls[0].BackColour = colour;  // 已有则仅更新颜色
```

**修复：** 玩家点分支完全采用与 Boss 相同的 `Count == 0` 保护模式。

---

### 2. Update(MovementInfo) 覆盖字典条目前未 Dispose 旧控件

**根因：** `Update(MovementInfo)` 每次调用都无条件 `new DXImageControl` 并直接覆盖 
`MapInfoObjects` 字典中的旧条目，旧控件未调用 `Dispose()` 就被丢弃，
其持有的 D3D 资源无法及时释放（尤其在地图重加载时集中触发）。

**修复：** 覆盖字典条目前先检查并 Dispose 旧控件，与 `Update(NPCInfo)` 的处理方式保持一致。

---

## 涉及文件

| 文件 | 改动性质 |
|---|---|
| `Client/Scenes/Views/MiniMapDialog.cs` | 修改（Count 保护 + 覆盖前 Dispose 旧控件） |

## 与其他 PR 的关系

本 PR 修改文件与其他所有 PR 完全不重叠，可独立合入，无顺序要求。
```